### PR TITLE
Allow redis client with auth credentials

### DIFF
--- a/lib/primus-redis.js
+++ b/lib/primus-redis.js
@@ -17,8 +17,8 @@ var PrimusRedis = module.exports = function (primus, options) {
     }
 
     return redis.createClient(
-        options.redis.host, 
         options.redis.port, 
+        options.redis.host, 
         options.redis.opts
       );
   }

--- a/lib/primus-redis.js
+++ b/lib/primus-redis.js
@@ -16,7 +16,11 @@ var PrimusRedis = module.exports = function (primus, options) {
       );
     }
 
-    return redis.createClient(options.redis);
+    return redis.createClient(
+        options.redis.host, 
+        options.redis.port, 
+        options.redis.opts
+      );
   }
 
   channel = options.redis.channel || 'primus';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "primus-redis-with-auth",
-  "version": "0.1.1-1",
+  "version": "0.1.1-2,
   "description": "Redis plugin for Primus with Redis Authentication",
   "dependencies": {
     "redis": "0.9.x",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "primus-redis",
+  "name": "primus-redis-with-auth",
   "version": "0.1.1-1",
-  "description": "Redis plugin for Primus",
+  "description": "Redis plugin for Primus with Redis Authentication",
   "dependencies": {
     "redis": "0.9.x",
     "redis-sentinel": "0.0.x"
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/mmalecki/primus-redis.git"
+    "url": "https://github.com/charyorde/primus-redis.git"
   },
   "scripts": {
     "test": "node test/simple-test.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "primus-redis-with-auth",
-  "version": "0.1.1-2,
+  "version": "0.1.1-2",
   "description": "Redis plugin for Primus with Redis Authentication",
   "dependencies": {
     "redis": "0.9.x",


### PR DESCRIPTION
Makes it easy to do this:

```
this.primusServer = new Primus(server, {
  host: redishost,
  port: redisport
  opts: {
    no_ready_check: true,
    auth_path: redispass
  }
}
```

It resolves issues such as `ERR Error: Ready check failed: NOAUTH Authentication required.` on redis servers that require authentication.
