### PR TITLE
Latest Primus compatibility and housekeeping

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
-  - "0.11"
+  - "6"
+  - "4"
+  - "0.12"
   - "0.10"
-  - "0.8"
 services:
   - redis-server

--- a/lib/primus-redis.js
+++ b/lib/primus-redis.js
@@ -36,22 +36,25 @@ var PrimusRedis = module.exports = function (primus, options) {
     publishQueue.length = 0;
   });
 
-  primus.write = function (data) {
-    //
-    // Waiting until we're subscribed is the best we can do to ensure that
-    // messages are delivered.
-    //
-    if (subscribed) {
-      pub.publish(channel, data, function (err) {
-        if (err) {
-          publishQueue.push(data);
-          subscribed = false;
-        }
-      });
-      return;
+  Object.defineProperty(primus, 'write', {
+    configurable: true,
+    value: function write (data) {
+      //
+      // Waiting until we're subscribed is the best we can do to ensure that
+      // messages are delivered.
+      //
+      if (subscribed) {
+        pub.publish(channel, data, function (err) {
+          if (err) {
+            publishQueue.push(data);
+            subscribed = false;
+          }
+        });
+        return;
+      }
+      publishQueue.push(data);
     }
-    publishQueue.push(data);
-  };
+  });
 };
 
 // Hack so that you can `primus.use(require('primus-redis'))`.

--- a/package.json
+++ b/package.json
@@ -7,9 +7,11 @@
     "redis-sentinel": "^0.0.0 || ^0.1.0 || ^0.2.0 || ^0.3.0"
   },
   "devDependencies": {
+    "assert-called": "~0.1.2",
     "primus": "1.4.x",
-    "ws": "0.4.x",
-    "assert-called": "~0.1.2"
+    "redis": "^2.6.2",
+    "redis-sentinel": "^0.3.3",
+    "ws": "0.4.x"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "assert-called": "~0.1.2",
-    "primus": "1.4.x",
+    "primus": "^5.2.2",
     "redis": "^2.6.2",
     "redis-sentinel": "^0.3.3",
     "ws": "0.4.x"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.1-1",
   "description": "Redis plugin for Primus",
   "peerDependencies": {
+    "primus": "^1.4.x || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
     "redis": "^0.9.x || ^1.0.0 || ^2.0.0",
     "redis-sentinel": "^0.0.0 || ^0.1.0 || ^0.2.0 || ^0.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "primus-redis",
   "version": "0.1.1-1",
   "description": "Redis plugin for Primus",
-  "dependencies": {
-    "redis": "0.9.x",
-    "redis-sentinel": "0.0.x"
+  "peerDependencies": {
+    "redis": "^0.9.x || ^1.0.0 || ^2.0.0",
+    "redis-sentinel": "^0.0.0 || ^0.1.0 || ^0.2.0 || ^0.3.0"
   },
   "devDependencies": {
     "primus": "1.4.x",

--- a/test/simple-test.js
+++ b/test/simple-test.js
@@ -12,13 +12,15 @@ var server = http.createServer(),
 function getPrimus() {
   var server = http.createServer();
   var primus = new Primus(server, {
+    plugin: {
+      Redis: PrimusRedis
+    },
     redis: {
       host: 'localhost',
       port: 6379
     },
     transformer: 'websockets'
   });
-  primus.use('Redis', PrimusRedis);
   server.listen(PORT++);
   return primus;
 }


### PR DESCRIPTION
1) Fixed latest primus compatibility
I fixed compatibility with the latest primus; while maintaining backwards compatibility.

2) Moved redis deps to peer deps
IMO the redis dependencies are better suited as peer dependencies, so users can use whatever compatible version they please.

3) Made test more relevant to current stacks
I updated the dev deps to later builds while maintaining node v0.10.x ci tests passing. Note that this module should still work fine with node v0.8.x. I just removed it from CI and added new node versions.
